### PR TITLE
rename grammars to prevent leaking into javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
         "grammars": [
             {
                 "language": "lightscript",
-                "scopeName": "source.js",
-                "path": "./syntaxes/js.tmLanguage"
+                "scopeName": "source.lsc",
+                "path": "./syntaxes/lsc.tmLanguage"
             }
         ]
     }

--- a/syntaxes/lsc.tmLanguage
+++ b/syntaxes/lsc.tmLanguage
@@ -4214,6 +4214,6 @@
 		</dict>
 	</dict>
 	<key>scopeName</key>
-	<string>source.js</string>
+	<string>source.lsc</string>
 </dict>
 </plist>


### PR DESCRIPTION
The extension was leaking into JavaScript files and breaking highlighting. Tested locally which fixed the issue and LightScript highlighting still works the same.